### PR TITLE
feat: optionally integrate with amman for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Command line interface to the Metaplex SDK.
 
+## Amman Integration
+
+When running against the `local` cluster you can enable [amman] integration in order to
+diagnose transaction in the [amman-explorer].
+
+Simply run `export MPLEX_AMMAN=1` in the same terminal from which you run the `mplex` command.
+
+TODO: we may provide an alternative command here, i.e. `mplexa` or similar which will have this
+environment variable set.
+
 ## Examples
 
 ### Preparation
@@ -47,3 +57,4 @@ $env:DEBUG = 'mplex:(info|error)'
 <!-- Links -->
 
 [amman]:https://github.com/metaplex-foundation/amman
+[amman-explorer]:https://amman-explorer.metaplex.com/

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
+    "@metaplex-foundation/amman-client": "^0.2.2",
     "@metaplex-foundation/js": "^0.16.1",
     "@solana/web3.js": "^1.63.1",
     "debug": "^4.3.4",
@@ -47,7 +48,6 @@
   },
   "devDependencies": {
     "@metaplex-foundation/amman": "^0.12.0",
-    "@metaplex-foundation/amman-client": "^0.2.2",
     "@types/debug": "^4.1.7",
     "@types/tape": "^4.13.2",
     "@types/yargs": "^17.0.13",

--- a/src/actions/airdrop.ts
+++ b/src/actions/airdrop.ts
@@ -1,14 +1,28 @@
 import { Connection, LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+import { tryAmman } from '../utils/amman'
 
 export async function airdrop(
   connection: Connection,
   publicKey: PublicKey,
   amount: number
 ) {
-  const sig = await connection.requestAirdrop(
-    publicKey,
-    amount * LAMPORTS_PER_SOL
-  )
-  const signatureResult = await connection.confirmTransaction(sig)
-  return { signature: sig, signatureResult }
+  let signatureResult
+  let signature
+
+  const amman = tryAmman()
+  if (amman != null) {
+    ;({ signature, signatureResult } = await amman.airdrop(
+      connection,
+      publicKey,
+      amount
+    ))
+  } else {
+    signature = await connection.requestAirdrop(
+      publicKey,
+      amount * LAMPORTS_PER_SOL
+    )
+    signatureResult = await connection.confirmTransaction(signature)
+  }
+
+  return { signature, signatureResult }
 }

--- a/src/cli/mplex.ts
+++ b/src/cli/mplex.ts
@@ -10,6 +10,7 @@ import { strict as assert } from 'assert'
 import { cmdAirdrop } from './commands/airdrop'
 import { closeConnection } from '../utils/connection'
 import { logError } from '../utils/log'
+import { MplexAmman } from 'src/utils/amman'
 
 const commands = yargs(hideBin(process.argv))
   .command(
@@ -82,6 +83,8 @@ async function main() {
 
         assert(typeof cluster === 'string', 'Cluster needs to be a string')
         assertDevCluster(cluster)
+
+        MplexAmman.init(cluster)
 
         const { connection } = await cmdAirdrop(
           cluster,

--- a/src/utils/amman.ts
+++ b/src/utils/amman.ts
@@ -1,0 +1,40 @@
+import { Amman } from '@metaplex-foundation/amman-client'
+import { ClusterWithLocal } from '../types'
+
+const programIds = {
+  hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk: 'auctionHouse',
+  CnDYGRdU51FsSyLnVgSd19MCFxA4YHT5h3nacvCKMPUJ: 'candyGuard',
+  CndyV3LdqHUfDLmE5naZjVN8rBZz4tqhdefbAnjHG3JR: 'candyMachineCore',
+  metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s: 'tokenMetadata',
+  gatem74V238djXdzWnJf94Wo1DcnuGkfijbf3AuBhfs: 'solanaGateway',
+}
+
+export class MplexAmman {
+  private readonly _amman: Amman | undefined
+
+  private constructor(cluster: ClusterWithLocal) {
+    // At this point we require the MPLEX_AMMAN env var to be set, but we could
+    // also try to connect to amman relay and enable it magically.
+    // Alternatively we could provide a wrapper binary which calls `mplex` with
+    // that env var set.
+    if (cluster === 'local' && process.env.MPLEX_AMMAN != null) {
+      this._amman = Amman.instance({
+        knownLabels: programIds,
+      })
+    }
+  }
+
+  get amman(): Amman | undefined {
+    return this._amman
+  }
+
+  private static _instance: MplexAmman | undefined
+  static init(cluster: ClusterWithLocal) {
+    MplexAmman._instance = new MplexAmman(cluster)
+  }
+  static get amman(): Amman | undefined {
+    return MplexAmman._instance?.amman
+  }
+}
+
+export const amman = () => MplexAmman.amman

--- a/src/utils/amman.ts
+++ b/src/utils/amman.ts
@@ -1,5 +1,6 @@
 import { Amman } from '@metaplex-foundation/amman-client'
 import { ClusterWithLocal } from '../types'
+import { logDebug } from '../utils/log'
 
 const programIds = {
   hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk: 'auctionHouse',
@@ -17,10 +18,17 @@ export class MplexAmman {
     // also try to connect to amman relay and enable it magically.
     // Alternatively we could provide a wrapper binary which calls `mplex` with
     // that env var set.
-    if (cluster === 'local' && process.env.MPLEX_AMMAN != null) {
-      this._amman = Amman.instance({
-        knownLabels: programIds,
-      })
+    if (cluster === 'local') {
+      if (process.env.MPLEX_AMMAN != null) {
+        this._amman = Amman.instance({
+          knownLabels: programIds,
+        })
+        logDebug('Enabled amman integration')
+      } else {
+        logDebug(
+          `Set env var 'MPLEX_AMMAN=1' in order to enable amman integration when running on local cluster`
+        )
+      }
     }
   }
 
@@ -37,4 +45,4 @@ export class MplexAmman {
   }
 }
 
-export const amman = () => MplexAmman.amman
+export const tryAmman = () => MplexAmman.amman


### PR DESCRIPTION
Adding amman integration when running on local cluster which is enabled via the `MPLEX_AMMAN`
environment variable.

This will use amman methods were possible as well as cause mplex to set transaction and account
labels where it makes sense. This allows diagnosing transactions via the [amman
explorer](https://amman-explorer.metaplex.com/) when using the mplex CLI.

The below screenshot shows what this looks like when integration is turned on.

<img width="846" alt="Screen Shot 2022-10-04 at 2 34 40 PM" src="https://user-images.githubusercontent.com/192891/193923536-f79fe27c-56f7-45b4-af37-a2743d49dd40.png">

